### PR TITLE
Correctly handle core status for navigation structures

### DIFF
--- a/structure-audit.py
+++ b/structure-audit.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
             'fuel_expires',
             'fuel_rate',
             'jump_fuel',
-            'has_core'
+            'needs_core'
         ]
         writer = csv.writer(sys.stdout)
         writer.writerow(columns)

--- a/structurebot.py
+++ b/structurebot.py
@@ -59,7 +59,7 @@ try:
         if args.structure_state and (structure.vulnerable or structure.reinforced):
             state = structure.state.replace('_', ' ').title()
             message.append('{} until {}'.format(state, structure.state_timer_end))
-        if args.core_state and not structure.has_core:
+        if args.core_state and structure.needs_core:
             message.append('No core installed')
         if message:
             messages.append(u'\n'.join([u'{}'.format(structure.name)] + message))

--- a/structurebot/citadels.py
+++ b/structurebot/citadels.py
@@ -138,6 +138,12 @@ class Structure(object):
             return True
         return False
 
+    @property
+    def needs_core(self):
+        if self.type.group.name.startswith('Upwell') or self.has_core:
+            return False
+        return True
+
     @classmethod
     def from_corporation(cls, corporation_name, assets=None):
         structure_list = []

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -23,6 +23,7 @@ class TestStructureDogma(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         raitaru_type = assets.Type.from_name('Raitaru')
+        ansiblex_type = assets.Type.from_name('Ansiblex Jump Gate')
         manufacturing_type = assets.Type.from_name('Standup Manufacturing Plant I')
         research_type = assets.Type.from_name('Standup Research Lab I')
         quantum_core = assets.Type.from_name('Raitaru Upwell Quantum Core')
@@ -32,9 +33,18 @@ class TestStructureDogma(unittest.TestCase):
         cls.raitaru = citadels.Structure(1, type_id=raitaru_type.type_id,
                                          type_name=raitaru_type.name,
                                          fitting=raitaru_fitting)
+        raitaru_no_core_fitting = assets.Fitting(ServiceSlot=[manufacturing_type,
+                                                              research_type])
+        cls.no_core_raitaru = citadels.Structure(2, type_id=raitaru_type.type_id,
+                                                 type_name=raitaru_type.name,
+                                                 fitting=raitaru_no_core_fitting)
+        cls.ansiblex = citadels.Structure(3, type_id=ansiblex_type.type_id,
+                                          type_name=ansiblex_type.name)
 
     def test_fuel(self):
         self.assertEqual(self.raitaru.fuel_rate, 18)
 
     def test_core(self):
-        self.assertTrue(self.raitaru.has_core)
+        self.assertFalse(self.raitaru.needs_core)
+        self.assertTrue(self.no_core_raitaru.needs_core)
+        self.assertFalse(self.ansiblex.needs_core)


### PR DESCRIPTION
Nav structures were reporting cores needed because of missing logic